### PR TITLE
Fix Leaflet icon size property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ library.add(faArrowRight,faBackward,faCalculator,faChevronDown,faChevronRight,fa
 let DefaultIcon = L.icon({
     iconUrl: icon,
     shadowUrl: iconShadow,
-    conSize: [25, 41],
+    iconSize: [25, 41],
     iconAnchor: [13, 41]
 });
 


### PR DESCRIPTION
## Summary
- fix typo in Leaflet icon configuration that prevented setting the icon size

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
