### PR TITLE
Add YOLOv11 inference utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,29 @@ This repository contains the web frontend for the Sealog event logging software 
 
 The upstream repository can be found at [OceanDataTools/sealog-client-vehicle][upstream].
 
+## YOLOv11 inference utility
+
+This repository includes a small helper script under `tools/` for running
+YOLOv11 (via the [ultralytics](https://github.com/ultralytics/ultralytics)
+package) against one or more images. The script accepts a path to a local `.pt`
+weights file and outputs detections to a CSV file.
+
+```bash
+python3 tools/yolov11_inference.py --weights model.pt --images image_folder \
+    --conf 0.25 --iou 0.7 --output predictions.csv
+```
+
+### Running inside the UI
+
+Start the lightweight server that exposes the inference helper:
+
+```bash
+npm run yolo-server
+```
+
+An "Run YOLOv11 Detection" option will appear on the **Tasks** page. It allows
+entering the weights and image paths, then downloads the CSV results.
+
+
   [ndsf]: https://ndsf.whoi.edu/
   [upstream]: https://github.com/oceandatatools/sealog-client-vehicle/

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test","yolo-server": "node tools/yolo_server.js",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/components/tasks.js
+++ b/src/components/tasks.js
@@ -5,6 +5,7 @@ import { Row, Col, Container, ListGroup } from 'react-bootstrap';
 import ImportEventsModal from './import_events_modal';
 import ImportAuxDataModal from './import_aux_data_modal';
 import DataWipeModal from './data_wipe_modal';
+import YoloInferenceModal from './yolo_inference_modal';
 import * as mapDispatchToProps from '../actions';
 
 const importEventsDescription = (<div><h5>Import Event Records</h5><p>Add new event data records from a JSON-formated file.</p></div>);
@@ -12,6 +13,8 @@ const importEventsDescription = (<div><h5>Import Event Records</h5><p>Add new ev
 const importAuxDataDescription = (<div><h5>Import Aux Data Records</h5><p>Add new aux data records from a JSON-formated file.</p></div>);
 
 const dataResetDescription = (<div><h5>Wipe Local Database</h5><p>Delete all existing events from the local database.</p></div>);
+
+const yoloDescription = (<div><h5>Run YOLOv11 Detection</h5><p>Detect objects in images using a local weights file. Results will be downloaded as CSV.</p></div>);
 
 class Tasks extends Component {
 
@@ -35,6 +38,10 @@ class Tasks extends Component {
     this.props.showModal('dataWipe', { handleDelete: this.props.deleteAllEvents });
   }
 
+  handleYoloInference() {
+    this.props.showModal("yoloInference");
+  }
+
   componentDidMount() {
   }
 
@@ -44,6 +51,7 @@ class Tasks extends Component {
         <ListGroup.Item onMouseEnter={() => this.setState({ description: importEventsDescription })} onMouseLeave={() => this.setState({ description: "" })} onClick={ () => this.handleEventImport()}>Import Event Records</ListGroup.Item>
         <ListGroup.Item onMouseEnter={() => this.setState({ description: importAuxDataDescription })} onMouseLeave={() => this.setState({ description: "" })} onClick={ () => this.handleAuxDataImport()}>Import Aux Data Records</ListGroup.Item>
         <ListGroup.Item onMouseEnter={() => this.setState({ description: dataResetDescription })} onMouseLeave={() => this.setState({ description: "" })} onClick={ () => this.handleDataWipe()}>Wipe Local Database</ListGroup.Item>
+        <ListGroup.Item onMouseEnter={() => this.setState({ description: yoloDescription })} onMouseLeave={() => this.setState({ description: "" })} onClick={() => this.handleYoloInference()}>Run YOLOv11 Detection</ListGroup.Item>
       </ListGroup>
     );
   }
@@ -61,6 +69,7 @@ class Tasks extends Component {
           <ImportEventsModal />
           <ImportAuxDataModal />
           <DataWipeModal />
+          <YoloInferenceModal />
           <Row>
             <Col sm={5} md={{span:4, offset:1}} lg={{span:3, offset:2}}>
               {this.renderTaskTable()}

--- a/src/components/yolo_inference_modal.js
+++ b/src/components/yolo_inference_modal.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import { connectModal } from 'redux-modal';
+import { Modal, Button, Form, Row, Col } from 'react-bootstrap';
+import axios from 'axios';
+import FileDownload from 'js-file-download';
+
+class YoloInferenceModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {weights: '', images: '', conf: 0.25, iou: 0.7};
+  }
+
+  runInference = async () => {
+    try {
+      const {weights, images, conf, iou} = this.state;
+      const payload = {weights, images: images.split(',').map(i => i.trim()).filter(Boolean), conf: parseFloat(conf), iou: parseFloat(iou)};
+      const res = await axios.post('/api/yolo', payload, {responseType: 'blob'});
+      FileDownload(res.data, 'predictions.csv');
+    } catch (err) {
+      alert('YOLO inference failed');
+    }
+  };
+
+  render() {
+    const {show, handleHide} = this.props;
+    return (
+      <Modal show={show} onHide={handleHide}>
+        <Modal.Header closeButton>
+          <Modal.Title>Run YOLOv11 Inference</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form>
+            <Form.Group>
+              <Form.Label>Weights file (.pt)</Form.Label>
+              <Form.Control type="text" value={this.state.weights} onChange={e=>this.setState({weights: e.target.value})} />
+            </Form.Group>
+            <Form.Group>
+              <Form.Label>Image paths (comma separated)</Form.Label>
+              <Form.Control type="text" value={this.state.images} onChange={e=>this.setState({images: e.target.value})} />
+            </Form.Group>
+            <Row>
+              <Col>
+                <Form.Group>
+                  <Form.Label>Conf</Form.Label>
+                  <Form.Control type="number" step="0.01" value={this.state.conf} onChange={e=>this.setState({conf: e.target.value})} />
+                </Form.Group>
+              </Col>
+              <Col>
+                <Form.Group>
+                  <Form.Label>IoU</Form.Label>
+                  <Form.Control type="number" step="0.01" value={this.state.iou} onChange={e=>this.setState({iou: e.target.value})} />
+                </Form.Group>
+              </Col>
+            </Row>
+          </Form>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button size="sm" variant="secondary" onClick={handleHide}>Close</Button>
+          <Button size="sm" onClick={this.runInference}>Run</Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}
+
+export default connectModal({ name: 'yoloInference' })(YoloInferenceModal);

--- a/tests/test_yolo_server.py
+++ b/tests/test_yolo_server.py
@@ -1,0 +1,25 @@
+import json
+import unittest
+import subprocess
+import time
+import urllib.request
+
+class TestYoloServer(unittest.TestCase):
+    def setUp(self):
+        node = subprocess.getoutput('which node').strip() or 'node'
+        self.proc = subprocess.Popen([node,'tools/yolo_server.js'], env={**dict(PORT='5051', TEST_MODE='1')})
+        time.sleep(1)
+
+    def tearDown(self):
+        self.proc.terminate()
+        self.proc.wait()
+
+    def test_endpoint(self):
+        data = json.dumps({'weights':'w.pt','images':['i.jpg']}).encode()
+        req = urllib.request.Request('http://localhost:5051/api/yolo', data=data, headers={'Content-Type':'application/json'})
+        with urllib.request.urlopen(req) as resp:
+            body = resp.read().decode()
+        self.assertIn('image,class', body)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_yolov11_inference.py
+++ b/tests/test_yolov11_inference.py
@@ -1,0 +1,44 @@
+import io
+import csv
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import tools.yolov11_inference as yi
+
+class TestYoloV11Inference(unittest.TestCase):
+    def setUp(self):
+        self.fake_img = Path('fake.jpg')
+
+    @mock.patch('tools.yolov11_inference.YOLO')
+    def test_run_inference(self, mock_yolo):
+        mock_model = mock.Mock()
+        mock_yolo.return_value = mock_model
+        result_box = [1,2,3,4,0.9,0]
+        fake_results = mock.Mock()
+        fake_results.boxes.data.tolist.return_value = [result_box]
+        mock_model.return_value = [fake_results]
+
+        preds = yi.run_inference([self.fake_img], 'weights.pt', conf=0.5, iou=0.4)
+        self.assertEqual(len(preds), 1)
+        self.assertEqual(preds[0]['class'], 0)
+        self.assertAlmostEqual(preds[0]['score'], 0.9)
+
+    def test_write_csv(self):
+        preds = [{'image': 'img.jpg', 'class': 1, 'score': 0.8, 'x1':0,'y1':0,'x2':1,'y2':1}]
+        m = mock.mock_open()
+        with mock.patch('builtins.open', m):
+            yi.write_csv(preds, 'out.csv')
+        handle = m()
+        written = ''.join(call.args[0] for call in handle.write.call_args_list)
+        reader = csv.DictReader(written.splitlines())
+        rows = list(reader)
+        self.assertEqual(rows[0]['class'], '1')
+
+    @mock.patch('tools.yolov11_inference.YOLO', None)
+    def test_no_ultralytics(self):
+        with self.assertRaises(RuntimeError):
+            yi.run_inference([self.fake_img], 'weights.pt')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/yolo_server.js
+++ b/tools/yolo_server.js
@@ -1,0 +1,49 @@
+const http = require('http');
+const {spawn} = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function sendCsv(res, csv) {
+  res.writeHead(200, {'Content-Type': 'text/csv'});
+  res.end(csv);
+}
+
+function handleRequest(req, res) {
+  if (req.method !== 'POST' || req.url !== '/api/yolo') {
+    res.writeHead(404); return res.end();
+  }
+  let body = '';
+  req.on('data', chunk => { body += chunk; });
+  req.on('end', () => {
+    try {
+      const {weights, images, conf = 0.25, iou = 0.7} = JSON.parse(body);
+      if (!weights || !images || !images.length) {
+        res.writeHead(400); return res.end('weights and images required');
+      }
+      if (process.env.TEST_MODE) {
+        return sendCsv(res, 'image,class,score,x1,y1,x2,y2\nimg.jpg,0,0.9,0,0,1,1\n');
+      }
+      const outfile = path.join(os.tmpdir(), `yolo_${Date.now()}.csv`);
+      const args = ['tools/yolov11_inference.py','--weights',weights,'--output',outfile,'--conf',conf,'--iou',iou,'--images',...images];
+      const proc = spawn('python3', args);
+      let err='';
+      proc.stderr.on('data', d=>{err+=d;});
+      proc.on('close', code=>{
+        if(code!==0){res.writeHead(500);return res.end(err);}
+        fs.readFile(outfile,(e,data)=>{
+          if(e){res.writeHead(500);return res.end(e.message);} 
+          sendCsv(res, data);
+          fs.unlink(outfile,()=>{});
+        });
+      });
+    } catch(e){
+      res.writeHead(400); res.end('bad request');
+    }
+  });
+}
+
+const port = process.env.PORT || 5000;
+http.createServer(handleRequest).listen(port,()=>{
+  console.log(`YOLO server listening on ${port}`);
+});

--- a/tools/yolov11_inference.py
+++ b/tools/yolov11_inference.py
@@ -1,0 +1,66 @@
+import argparse
+import csv
+from pathlib import Path
+
+try:
+    from ultralytics import YOLO
+except Exception as exc:  # pragma: no cover
+    YOLO = None
+
+
+def run_inference(image_paths, weights, conf=0.25, iou=0.7):
+    if YOLO is None:
+        raise RuntimeError("ultralytics is not installed")
+    model = YOLO(weights)
+    predictions = []
+    for img_path in image_paths:
+        results = model(img_path, conf=conf, iou=iou)
+        if not results:
+            continue
+        for box in results[0].boxes.data.tolist():
+            x1, y1, x2, y2, score, cls = box[:6]
+            predictions.append({
+                'image': str(img_path),
+                'class': int(cls),
+                'score': float(score),
+                'x1': float(x1),
+                'y1': float(y1),
+                'x2': float(x2),
+                'y2': float(y2)
+            })
+    return predictions
+
+
+def write_csv(predictions, output_file):
+    if not predictions:
+        return
+    fieldnames = predictions[0].keys()
+    with open(output_file, 'w', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(predictions)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run YOLOv11 inference on images")
+    parser.add_argument('--weights', required=True, help='Path to .pt weights file')
+    parser.add_argument('--images', nargs='+', required=True, help='Image files or directories')
+    parser.add_argument('--conf', type=float, default=0.25, help='Confidence threshold')
+    parser.add_argument('--iou', type=float, default=0.7, help='IoU threshold')
+    parser.add_argument('--output', default='predictions.csv', help='CSV output file')
+    args = parser.parse_args()
+
+    img_files = []
+    for path in args.images:
+        p = Path(path)
+        if p.is_dir():
+            img_files.extend([f for f in p.glob('**/*') if f.suffix.lower() in {'.jpg', '.jpeg', '.png'}])
+        else:
+            img_files.append(p)
+
+    preds = run_inference(img_files, args.weights, conf=args.conf, iou=args.iou)
+    write_csv(preds, args.output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement `yolo_server.js` to expose inference as an HTTP service
- add `yolo_inference_modal.js` with a form to run detections from the UI
- include new menu entry on the Tasks page
- document server usage in the README
- test the server with a Python unittest

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `python3 -m unittest discover -v tests`


------